### PR TITLE
Feature/extended lua st api

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,6 +26,10 @@ BraceWrapping:
   SplitEmptyRecord: true
   SplitEmptyNamespace: true
 BreakBeforeBraces: Custom
+AllowShortLambdasOnASingleLine: false
+AllowAllArgumentsOnNextLine: false
+BinPackArguments: false
+BinPackParameters: false
 BreakConstructorInitializers: AfterColon
 BreakConstructorInitializersBeforeComma: false
 ColumnLimit: 0

--- a/src/Views.Win32/lua/LuaConsole.cpp
+++ b/src/Views.Win32/lua/LuaConsole.cpp
@@ -649,4 +649,11 @@ void lua_pushcallback(lua_State* L, void* key)
 {
     lua_pushlightuserdata(L, key);
     lua_gettable(L, LUA_REGISTRYINDEX);
+    free(key);
+    key = nullptr;
+}
+
+void lua_freecallback(void* key)
+{
+    free(key);
 }

--- a/src/Views.Win32/lua/LuaConsole.h
+++ b/src/Views.Win32/lua/LuaConsole.h
@@ -164,6 +164,7 @@ void repaint_visuals();
 
 void* lua_tocallback(lua_State* L, int i);
 void lua_pushcallback(lua_State* L, void* key);
+void lua_freecallback(void* key);
 
 extern std::vector<t_lua_environment*> g_lua_environments;
 

--- a/src/Views.Win32/lua/LuaConsole.h
+++ b/src/Views.Win32/lua/LuaConsole.h
@@ -162,6 +162,9 @@ void invalidate_visuals();
  */
 void repaint_visuals();
 
+void* lua_tocallback(lua_State* L, int i);
+void lua_pushcallback(lua_State* L, void* key);
+
 extern std::vector<t_lua_environment*> g_lua_environments;
 
 /**

--- a/src/Views.Win32/lua/LuaRegistry.cpp
+++ b/src/Views.Win32/lua/LuaRegistry.cpp
@@ -202,6 +202,9 @@ const luaL_Reg MOVIE_FUNCS[] = {
 const luaL_Reg SAVESTATE_FUNCS[] = {
 {"savefile", LuaCore::Savestate::SaveFileSavestate},
 {"loadfile", LuaCore::Savestate::LoadFileSavestate},
+{"do_file", LuaCore::Savestate::do_file},
+{"do_slot", LuaCore::Savestate::do_slot},
+{"do_memory", LuaCore::Savestate::do_memory},
 {NULL, NULL}};
 
 const luaL_Reg IOHELPER_FUNCS[] = {

--- a/src/Views.Win32/lua/modules/Savestate.h
+++ b/src/Views.Win32/lua/modules/Savestate.h
@@ -36,10 +36,16 @@ namespace LuaCore::Savestate
         return 0;
     }
 
+    static core_st_job lua_to_savestate_job(lua_State* l, const int i)
+    {
+        const std::string str = lua_tostring(l, i);
+        return str == "save" ? core_st_job_save : core_st_job_load;
+    }
+
     static int do_file(lua_State* L)
     {
         const std::filesystem::path path = lua_tostring(L, 1);
-        const auto job = static_cast<core_st_job>(lua_tointeger(L, 2));
+        const auto job = lua_to_savestate_job(L, 2);
         const auto callback = lua_tocallback(L, 3);
         const bool ignore_warnings = lua_toboolean(L, 4);
 
@@ -65,11 +71,57 @@ namespace LuaCore::Savestate
 
     static int do_slot(lua_State* L)
     {
+        const auto slot = lua_tointeger(L, 1) - 1;
+        const auto job = lua_to_savestate_job(L, 2);
+        const auto callback = lua_tocallback(L, 3);
+        const bool ignore_warnings = lua_toboolean(L, 4);
+
+        core_vr_wait_increment();
+        AsyncExecutor::invoke_async([=] {
+            core_vr_wait_decrement();
+            core_st_do_slot(slot, job, [=](const auto result, const std::vector<uint8_t>& buf) {
+                g_main_window_dispatcher->invoke([=] {
+                    if (!get_lua_class(L))
+                    {
+                        return;
+                    }
+                    lua_pushcallback(L, callback);
+                    lua_pushinteger(L, result);
+                    lua_pushlstring(L, (const char*)buf.data(), buf.size());
+                    lua_pcall(L, 2, 0, 0);
+                });
+            },
+                            ignore_warnings);
+        });
         return 0;
     }
 
     static int do_memory(lua_State* L)
     {
+        size_t buffer_len{};
+        const auto buffer_str = lua_tolstring(L, 1, &buffer_len);
+        const auto job = lua_to_savestate_job(L, 2);
+        const auto callback = lua_tocallback(L, 3);
+        const bool ignore_warnings = lua_toboolean(L, 4);
+
+        core_vr_wait_increment();
+        AsyncExecutor::invoke_async([=] {
+            core_vr_wait_decrement();
+            const auto buffer = std::vector<uint8_t>(buffer_str, buffer_str + buffer_len);
+            core_st_do_memory(buffer, job, [=](const auto result, const std::vector<uint8_t>& buf) {
+                g_main_window_dispatcher->invoke([=] {
+                    if (!get_lua_class(L))
+                    {
+                        return;
+                    }
+                    lua_pushcallback(L, callback);
+                    lua_pushinteger(L, result);
+                    lua_pushlstring(L, (const char*)buf.data(), buf.size());
+                    lua_pcall(L, 2, 0, 0);
+                });
+            },
+                              ignore_warnings);
+        });
         return 0;
     }
 } // namespace LuaCore::Savestate

--- a/src/Views.Win32/lua/modules/Savestate.h
+++ b/src/Views.Win32/lua/modules/Savestate.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <lua/LuaConsole.h>
+
 namespace LuaCore::Savestate
 {
     static int SaveFileSavestate(lua_State* L)
@@ -38,22 +40,22 @@ namespace LuaCore::Savestate
     {
         const std::filesystem::path path = lua_tostring(L, 1);
         const auto job = static_cast<core_st_job>(lua_tointeger(L, 2));
+        const auto callback = lua_tocallback(L, 3);
         const bool ignore_warnings = lua_toboolean(L, 4);
 
-        lua_pushvalue(L, 3);
-        // FIXME: BUG: This corrupts the registry!!! 
-        int callback_ref = luaL_ref(L, LUA_REGISTRYINDEX);
-        
         core_vr_wait_increment();
         AsyncExecutor::invoke_async([=] {
             core_vr_wait_decrement();
             core_st_do_file(path, job, [=](const auto result, const std::vector<uint8_t>& buf) {
                 g_main_window_dispatcher->invoke([=] {
-                    lua_rawgeti(L, LUA_REGISTRYINDEX, callback_ref);
+                    if (!get_lua_class(L))
+                    {
+                        return;
+                    }
+                    lua_pushcallback(L, callback);
                     lua_pushinteger(L, result);
                     lua_pushlstring(L, (const char*)buf.data(), buf.size());
                     lua_pcall(L, 2, 0, 0);
-                    luaL_unref(L, LUA_REGISTRYINDEX, callback_ref);
                 });
             },
                             ignore_warnings);

--- a/src/Views.Win32/resource.h
+++ b/src/Views.Win32/resource.h
@@ -515,6 +515,7 @@
 #define IDD_PLUGIN_CONFIG 40107
 #define IDR_INSPECT_LUA_FILE 40108
 #define TEXTFILE 40109
+#define IDR_API_LUA_FILE 40110
 #define IDC_STATIC -1
 
 // Next default values for new objects

--- a/src/Views.Win32/rsrc.rc
+++ b/src/Views.Win32/rsrc.rc
@@ -34,6 +34,8 @@ IDB_SOUND               BITMAP                  "icons\\plugin_audio.bmp"
 
 IDR_INSPECT_LUA_FILE    TEXTFILE                "..\\..\\lib\\inspect.lua"
 
+IDR_API_LUA_FILE    TEXTFILE                    "..\\..\\tools\\mupenapi.lua"
+
 /////////////////////////////////////////////////////////////////////////////
 //
 // Menu

--- a/tools/lua-examples/savestate_api.lua
+++ b/tools/lua-examples/savestate_api.lua
@@ -1,0 +1,42 @@
+print("Press 1 to save to 'out.st'")
+print("Press 2 to load from 'out.st'")
+print("Press 3 to save to slot 1")
+print("Press 4 to load from slot 1")
+print("Press 5 to save to memory")
+print("Press 6 to load from memory")
+
+local prev_keys = {}
+local memory_st = ""
+
+emu.atinterval(function()
+    local new_keys = input.diff(input.get(), prev_keys)
+
+    if new_keys["1"] then
+        savestate.do_file("out.st", "save", function(result, data)
+            print("saved " .. string.len(data) .. " bytes (result " .. result .. ")")
+        end)
+    elseif new_keys["2"] then
+        savestate.do_file("out.st", "load", function(result, data)
+            print("loaded " .. string.len(data) .. " bytes (result " .. result .. ")")
+        end)
+    elseif new_keys["3"] then
+        savestate.do_slot(1, "save", function(result, data)
+            print("saved " .. string.len(data) .. " bytes (result " .. result .. ")")
+        end)
+    elseif new_keys["4"] then
+        savestate.do_slot(1, "load", function(result, data)
+            print("loaded " .. string.len(data) .. " bytes (result " .. result .. ")")
+        end)
+    elseif new_keys["5"] then
+        savestate.do_memory("", "save", function(result, data)
+            memory_st = data
+            print("saved " .. string.len(data) .. " bytes (result " .. result .. ")")
+        end)
+    elseif new_keys["6"] then
+        savestate.do_memory(memory_st, "load", function(result, data)
+            print("loaded " .. string.len(data) .. " bytes (result " .. result .. ")")
+        end)
+    end
+
+    prev_keys = input.get()
+end)

--- a/tools/lua-examples/savestate_api_stress_test.lua
+++ b/tools/lua-examples/savestate_api_stress_test.lua
@@ -1,0 +1,8 @@
+function st() 
+    savestate.do_slot(1, "save", function(result, data) end)
+    savestate.do_memory("", "save", function(result, data) end)
+end
+
+emu.atinterval(st)
+emu.atdrawd2d(st)
+emu.atupdatescreen(st)

--- a/tools/mupenapi.lua
+++ b/tools/mupenapi.lua
@@ -19,6 +19,87 @@ savestate = {}
 iohelper = {}
 avi = {}
 
+---@enum Result
+---An enum containing results that can be returned by the core.
+local result = {
+    -- The operation completed successfully
+    res_ok = 0,
+
+    -- The operation was cancelled by the user
+    res_cancelled = 1,
+
+    -- The provided data has an invalid format
+    vcr_invalid_format = 2,
+    -- The provided file is inaccessible or does not exist
+    vcr_bad_file = 3,
+    -- The cheat data couldn't be written to disk
+    vcr_cheat_write_failed = 4,
+    -- The controller configuration is invalid
+    vcr_invalid_controllers = 5,
+    -- The movie's savestate is missing or invalid
+    vcr_invalid_savestate = 6,
+    -- The resulting frame is outside the bounds of the movie
+    vcr_invalid_frame = 7,
+    -- There is no rom which matches this movie
+    vcr_no_matching_rom = 8,
+    -- The VCR engine is idle, but must be active to complete this operation
+    vcr_idle = 9,
+    -- The provided freeze buffer is not from the currently active movie
+    vcr_not_from_this_movie = 10,
+    -- The movie's version is invalid
+    vcr_invalid_version = 11,
+    -- The movie's extended version is invalid
+    vcr_invalid_extended_version = 12,
+    -- The operation requires a playback or recording task
+    vcr_needs_playback_or_recording = 13,
+    -- The provided start type is invalid.
+    vcr_invalid_start_type = 14,
+    -- Another warp modify operation is already running
+    vcr_warp_modify_already_running = 15,
+    -- Warp modifications can only be performed during recording
+    vcr_warp_modify_needs_recording_task = 16,
+    -- The provided input buffer is empty
+    vcr_warp_modify_empty_input_buffer = 17,
+    -- Another seek operation is already running
+    vcr_seek_already_running = 18,
+    -- The seek operation could not be initiated due to a savestate not being loaded successfully
+    vcr_seek_savestate_load_failed = 19,
+    -- The seek operation can't be initiated because the seek savestate interval is 0
+    vcr_seek_savestate_interval_zero = 20,
+
+    -- Couldn't find a rom matching the provided movie
+    vr_no_matching_rom = 21,
+    -- An error occured during plugin loading
+    vr_plugin_error = 22,
+    -- The ROM or alternative rom source is invalid
+    vr_rom_invalid = 23,
+    -- The emulator isn't running yet
+    vr_not_running = 24,
+    -- Failed to open core streams
+    vr_file_open_failed = 25,
+
+    -- The core isn't launched
+    st_core_not_launched = 26,
+    -- The savestate file wasn't found
+    st_not_found = 27,
+    -- The savestate couldn't be written to disk
+    st_file_write_error = 28,
+    -- Couldn't decompress the savestate
+    st_decompression_error = 29,
+    -- The event queue was too long
+    st_event_queue_too_long = 30,
+    -- The CPU registers contained invalid values
+    st_invalid_registers = 31,
+
+    -- The plugin library couldn't be loaded
+    pl_load_library_failed = 32,
+    -- The plugin doesn't export a GetDllInfo function
+    pl_no_get_dll_info = 33,
+}
+
+---@alias ByteBuffer string
+---A byte buffer encoded as a string.
+
 ---@alias qword integer[] A representation of an 8 byte integer (quad word) as
 ---two 4 byte integers.
 
@@ -1012,6 +1093,33 @@ function savestate.savefile(filename) end
 ---@param filename string
 ---@return nil
 function savestate.loadfile(filename) end
+
+---@alias SavestateCallback fun(result: Result, data: ByteBuffer): nil
+---Represents a callback function for a savestate operation.
+
+---@alias SavestateJob "save" | "load"
+---Represents a savestate job.
+
+---Executes a savestate operation to a path.
+---@param path string The savestate's path.
+---@param job SavestateJob The job to set.
+---@param callback SavestateCallback The callback to call when the operation is complete.
+---@param ignore_warnings boolean | nil Whether warnings, such as those about ROM compatibility, shouldn't be shown. Defaults to `false`.
+function savestate.do_file(path, job, callback, ignore_warnings) end
+
+---Executes a savestate operation to a slot.
+---@param slot integer The slot to construct the savestate path with.
+---@param job SavestateJob The job to set.
+---@param callback SavestateCallback The callback to call when the operation is complete.
+---@param ignore_warnings boolean | nil Whether warnings, such as those about ROM compatibility, shouldn't be shown. Defaults to `false`.
+function savestate.do_slot(slot, job, callback, ignore_warnings) end
+
+---Executes a savestate operation in-memory.
+---@param buffer ByteBuffer The buffer to use for the operation. Can be empty if the `job` is `save`.
+---@param job SavestateJob The job to set.
+---@param callback SavestateCallback The callback to call when the operation is complete.
+---@param ignore_warnings boolean | nil Whether warnings, such as those about ROM compatibility, shouldn't be shown. Defaults to `false`.
+function savestate.do_memory(buffer, job, callback, ignore_warnings) end
 
 --#endregion
 

--- a/tools/mupenapi.lua
+++ b/tools/mupenapi.lua
@@ -19,82 +19,84 @@ savestate = {}
 iohelper = {}
 avi = {}
 
----@enum Result
----An enum containing results that can be returned by the core.
-Result = {
-    -- The operation completed successfully
-    res_ok = 0,
+Mupen = {
+    ---@enum Result
+    ---An enum containing results that can be returned by the core.
+    result = {
+        -- The operation completed successfully
+        res_ok = 0,
 
-    -- The operation was cancelled by the user
-    res_cancelled = 1,
+        -- The operation was cancelled by the user
+        res_cancelled = 1,
 
-    -- The provided data has an invalid format
-    vcr_invalid_format = 2,
-    -- The provided file is inaccessible or does not exist
-    vcr_bad_file = 3,
-    -- The cheat data couldn't be written to disk
-    vcr_cheat_write_failed = 4,
-    -- The controller configuration is invalid
-    vcr_invalid_controllers = 5,
-    -- The movie's savestate is missing or invalid
-    vcr_invalid_savestate = 6,
-    -- The resulting frame is outside the bounds of the movie
-    vcr_invalid_frame = 7,
-    -- There is no rom which matches this movie
-    vcr_no_matching_rom = 8,
-    -- The VCR engine is idle, but must be active to complete this operation
-    vcr_idle = 9,
-    -- The provided freeze buffer is not from the currently active movie
-    vcr_not_from_this_movie = 10,
-    -- The movie's version is invalid
-    vcr_invalid_version = 11,
-    -- The movie's extended version is invalid
-    vcr_invalid_extended_version = 12,
-    -- The operation requires a playback or recording task
-    vcr_needs_playback_or_recording = 13,
-    -- The provided start type is invalid.
-    vcr_invalid_start_type = 14,
-    -- Another warp modify operation is already running
-    vcr_warp_modify_already_running = 15,
-    -- Warp modifications can only be performed during recording
-    vcr_warp_modify_needs_recording_task = 16,
-    -- The provided input buffer is empty
-    vcr_warp_modify_empty_input_buffer = 17,
-    -- Another seek operation is already running
-    vcr_seek_already_running = 18,
-    -- The seek operation could not be initiated due to a savestate not being loaded successfully
-    vcr_seek_savestate_load_failed = 19,
-    -- The seek operation can't be initiated because the seek savestate interval is 0
-    vcr_seek_savestate_interval_zero = 20,
+        -- The provided data has an invalid format
+        vcr_invalid_format = 2,
+        -- The provided file is inaccessible or does not exist
+        vcr_bad_file = 3,
+        -- The cheat data couldn't be written to disk
+        vcr_cheat_write_failed = 4,
+        -- The controller configuration is invalid
+        vcr_invalid_controllers = 5,
+        -- The movie's savestate is missing or invalid
+        vcr_invalid_savestate = 6,
+        -- The resulting frame is outside the bounds of the movie
+        vcr_invalid_frame = 7,
+        -- There is no rom which matches this movie
+        vcr_no_matching_rom = 8,
+        -- The VCR engine is idle, but must be active to complete this operation
+        vcr_idle = 9,
+        -- The provided freeze buffer is not from the currently active movie
+        vcr_not_from_this_movie = 10,
+        -- The movie's version is invalid
+        vcr_invalid_version = 11,
+        -- The movie's extended version is invalid
+        vcr_invalid_extended_version = 12,
+        -- The operation requires a playback or recording task
+        vcr_needs_playback_or_recording = 13,
+        -- The provided start type is invalid.
+        vcr_invalid_start_type = 14,
+        -- Another warp modify operation is already running
+        vcr_warp_modify_already_running = 15,
+        -- Warp modifications can only be performed during recording
+        vcr_warp_modify_needs_recording_task = 16,
+        -- The provided input buffer is empty
+        vcr_warp_modify_empty_input_buffer = 17,
+        -- Another seek operation is already running
+        vcr_seek_already_running = 18,
+        -- The seek operation could not be initiated due to a savestate not being loaded successfully
+        vcr_seek_savestate_load_failed = 19,
+        -- The seek operation can't be initiated because the seek savestate interval is 0
+        vcr_seek_savestate_interval_zero = 20,
 
-    -- Couldn't find a rom matching the provided movie
-    vr_no_matching_rom = 21,
-    -- An error occured during plugin loading
-    vr_plugin_error = 22,
-    -- The ROM or alternative rom source is invalid
-    vr_rom_invalid = 23,
-    -- The emulator isn't running yet
-    vr_not_running = 24,
-    -- Failed to open core streams
-    vr_file_open_failed = 25,
+        -- Couldn't find a rom matching the provided movie
+        vr_no_matching_rom = 21,
+        -- An error occured during plugin loading
+        vr_plugin_error = 22,
+        -- The ROM or alternative rom source is invalid
+        vr_rom_invalid = 23,
+        -- The emulator isn't running yet
+        vr_not_running = 24,
+        -- Failed to open core streams
+        vr_file_open_failed = 25,
 
-    -- The core isn't launched
-    st_core_not_launched = 26,
-    -- The savestate file wasn't found
-    st_not_found = 27,
-    -- The savestate couldn't be written to disk
-    st_file_write_error = 28,
-    -- Couldn't decompress the savestate
-    st_decompression_error = 29,
-    -- The event queue was too long
-    st_event_queue_too_long = 30,
-    -- The CPU registers contained invalid values
-    st_invalid_registers = 31,
+        -- The core isn't launched
+        st_core_not_launched = 26,
+        -- The savestate file wasn't found
+        st_not_found = 27,
+        -- The savestate couldn't be written to disk
+        st_file_write_error = 28,
+        -- Couldn't decompress the savestate
+        st_decompression_error = 29,
+        -- The event queue was too long
+        st_event_queue_too_long = 30,
+        -- The CPU registers contained invalid values
+        st_invalid_registers = 31,
 
-    -- The plugin library couldn't be loaded
-    pl_load_library_failed = 32,
-    -- The plugin doesn't export a GetDllInfo function
-    pl_no_get_dll_info = 33,
+        -- The plugin library couldn't be loaded
+        pl_load_library_failed = 32,
+        -- The plugin doesn't export a GetDllInfo function
+        pl_no_get_dll_info = 33,
+    }
 }
 
 ---@alias ByteBuffer string

--- a/tools/mupenapi.lua
+++ b/tools/mupenapi.lua
@@ -21,7 +21,7 @@ avi = {}
 
 ---@enum Result
 ---An enum containing results that can be returned by the core.
-local result = {
+Result = {
     -- The operation completed successfully
     res_ok = 0,
 


### PR DESCRIPTION
# Summary

This PR implements the extended Lua savestate API (#295).

`mupenapi.lua` now defines a global table, `Mupen`, currently with only one other table inside it: the `result` enum, which maps directly to `core_result` from `core_types.h`

```lua

Mupen = {
    result = { ... }
}

```

To allow proper result handling for all Lua scripts without needing to add the load the definition file manually, the `mupenapi.lua` script is now injected into all running scripts. **This change breaks scripts which define a global `Mupen` table.**


