### PR TITLE
Update api file

### DIFF
--- a/src/Views.Win32/lua/LuaRegistry.cpp
+++ b/src/Views.Win32/lua/LuaRegistry.cpp
@@ -61,8 +61,6 @@ const luaL_Reg EMU_FUNCS[] = {
 {"set_ff", LuaCore::Emu::SetFastForward},
 {"speed", LuaCore::Emu::SetSpeed},
 {"speedmode", LuaCore::Emu::SetSpeedMode},
-// DEPRECATE: This is completely useless
-{"setgfx", LuaCore::Emu::SetGFX},
 
 {"getaddress", LuaCore::Emu::GetAddress},
 

--- a/src/Views.Win32/lua/modules/Emu.h
+++ b/src/Views.Win32/lua/modules/Emu.h
@@ -137,12 +137,6 @@ namespace LuaCore::Emu
         return 1;
     }
 
-    static int SetGFX(lua_State* L)
-    {
-        // stub for now
-        return 0;
-    }
-
     static int EmuPause(lua_State* L)
     {
         if (!lua_toboolean(L, 1))

--- a/tools/mupenapi.lua
+++ b/tools/mupenapi.lua
@@ -1,11 +1,11 @@
 ---@meta
 
--- version 1.2.0
+-- version 1.2.0.1
 
 -- This file has meta definitions for the functions implemented in mupen64.
--- https://github.com/mkdasher/mupen64-rr-lua-/blob/master/lua/LuaConsole.cpp
+-- https://github.com/mupen64/mupen64-rr-lua/blob/master/src/Views.Win32/lua/LuaRegistry.cpp
 
--- Additional (and slightly outdated) documentation can be found here:
+-- Additional (and very outdated) documentation can be found here:
 -- https://docs.google.com/document/d/1SWd-oAFBKsGmwUs0qGiOrk3zfX9wYHhi3x5aKPQS_o0
 
 emu = {}
@@ -96,20 +96,13 @@ Mupen = {
         pl_load_library_failed = 32,
         -- The plugin doesn't export a GetDllInfo function
         pl_no_get_dll_info = 33,
-    }
+    },
 }
 
----@alias ByteBuffer string
----A byte buffer encoded as a string.
+---The `lua_tostring` c function converts numbers to strings, so numbers are
+---acceptable to pass into some functions that use that function.
+---@alias tostringusable string|number
 
----@alias qword integer[] A representation of an 8 byte integer (quad word) as
----two 4 byte integers.
-
----@alias tostringusable string|number The `lua_tostring` c function converts
----numbers to strings, so numbers are acceptable to pass into some functions
----that use that function.
-
----@alias getrect {l: integer, t: integer, r: integer, b: integer}|{l: integer, t: integer, w: integer, h: integer}
 
 -- Global Functions
 --#region
@@ -117,17 +110,9 @@ Mupen = {
 ---Prints a value to the lua console.
 ---
 ---The data is formatted using the [inspect.lua library](https://github.com/kikito/inspect.lua).
----
 ---@param data any The data to print to the console.
 ---@return nil
 function print(data) end
-
-
----Prints a value to the lua console.
----@deprecated Use [print](lua://print).
----@param data any The data to print to the console.
----@return nil
-function printx(data) end
 
 ---Converts a value to a string using the [inspect.lua library](https://github.com/kikito/inspect.lua).
 ---@param value any
@@ -151,25 +136,23 @@ function os.exit(code, close) end
 -- emu functions
 --#region
 
----Displays the text `message` in the console. Similar to `print`, but only
----accepts strings or numbers. Also, `emu.console` does not insert a newline
----character. Because of this, `print` should be used instead.
+---Displays the text `message` in the console. Similar to `print`, but only accepts strings or numbers.
+---Also, `emu.console` does not insert a newline character.
+---Because of this, `print` should be used instead.
 ---@deprecated Use `print` instead.
 ---@param message tostringusable The string to print to the console.
 ---@return nil
 function emu.console(message) end
 
----Displays the text `message` in the status bar on the bottom while replacing
----any other text. The message will only display until the next frame.
+---Displays the text `message` in the status bar on the bottom while replacing any other text.
+---The message will only display until the next frame.
 ---@param message tostringusable The string to display on the status bar.
 ---@return nil
 function emu.statusbar(message) end
 
----Calls the function `f` every VI frame. For example, in Super Mario 64, the
----function will be called twice when you advance by one frame, whereas it will
----be called once in Ocarina of Time. If `unregister` is set to true, the
----function `f` will no longer be called when this event occurs, but it will
----error if you never registered the function.
+---Calls the function `f` every VI frame.
+---For example, in Super Mario 64, the function will be called twice when you advance by one frame, whereas it will be called once in Ocarina of Time.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called every VI frame.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
@@ -177,10 +160,8 @@ function emu.atvi(f, unregister) end
 
 ---Similar to `emu.atvi`, but for wgui drawing commands.
 ---Only drawing functions from the wgui namespace will work here, those from d2d will not.
----Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace. 
----If `unregister` is set to true, the function `f` will no
----longer be called when this event occurs, but it will error if you never
----registered the function.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called after every VI frame.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
@@ -188,118 +169,115 @@ function emu.atupdatescreen(f, unregister) end
 
 ---Similar to `emu.atvi`, but for d2d and wgui drawing commands.
 ---Drawing functions from both the d2d and wgui namespaces will work here, but it's recommended to put wgui drawcalls into the `emu.atupdatescreen` callback for efficiency and compatibility reasons.
----Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace. 
----If `unregister` is set to true, the function `f` will no
----longer be called when this event occurs, but it will error if you never
----registered the function.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called after every VI frame.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atdrawd2d(f, unregister) end
 
----Calls the function `f` every input frame. The function `f` receives an
----argument that seems to always be `0`. If `unregister` is set to true, the
----function `f` will no longer be called when this event occurs, but it will
----error if you never registered the function. Alias for `joypad.register`.
+---Calls the function `f` every input frame.
+---The function `f` receives an argument that seems to always be `0`.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(a: integer?): nil The function to be called every input frame. It receives an argument that seems to always be `0`.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atinput(f, unregister) end
 
----Calls the function `f` when the script is stopped. If `unregister` is set to
----true, the function `f` will no longer be called when this event occurs, but
----it will error if you never registered the function.
+---Calls the function `f` when the script is stopped.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called when the script is stopped.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atstop(f, unregister) end
 
 ---Defines a handler function that is called when a window receives a message.
----The only message that can be recieved is WM_MOUSEWHEEL for compatability.
----All other functionality as been deprecated. The message data is given to the
----function in 4 parameters. If `unregister` is set to true, the function `f`
----will no longer be called when this event occurs, but it will error if you]
----never registered the function.
+---The only message that can be received is WM_MOUSEWHEEL for compatibility.
+---All other functionality as been deprecated.
+---The message data is given to the function in 4 parameters.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(a: integer, b: integer, c: integer, d: integer): nil The function to be called when a window message is received. a: wnd, b: msg, c: wParam, d: lParam.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atwindowmessage(f, unregister) end
 
----Calls the function `f` constantly, even when the emulator is paused. If
----`unregister` is set to true, the function `f` will no longer be called when
----this event occurs, but it will error if you never registered the function.
+---Calls the function `f` constantly, even when the emulator is paused.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called constantly.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atinterval(f, unregister) end
 
----Calls the function `f` when a movie is played. If `unregister` is set to
----true, the function `f` will no longer be called when this event occurs, but
----it will error if you never registered the function.
+---Calls the function `f` when a movie is played.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called when a movie is played.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atplaymovie(f, unregister) end
 
----Calls the function `f` when a movie is stopped. If `unregister` is set to
----true, the function `f` will no longer be called when this event occurs, but
----it will error if you never registered the function.
+---Calls the function `f` when a movie is stopped.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called when a movie is stopped.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atstopmovie(f, unregister) end
 
----Calls the function `f` when a savestate is loaded. If `unregister` is set to
----true, the function `f` will no longer be called when this event occurs, but
----it will error if you never registered the function.
+---Calls the function `f` when a savestate is loaded.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called when a savestate is loaded.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atloadstate(f, unregister) end
 
----Calls the function `f` when a savestate is saved. If `unregister` is set to
----true, the function `f` will no longer be called when this event occurs, but
----it will error if you never registered the function.
+---Calls the function `f` when a savestate is saved.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called when a savestate is saved.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atsavestate(f, unregister) end
 
----Calls the function `f` when the emulator is reset. If `unregister` is set to
----true, the function `f` will no longer be called when this event occurs, but
----it will error if you never registered the function.
+---Calls the function `f` when the emulator is reset.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called when the emulator is reset.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atreset(f, unregister) end
 
----Calls the function `f` when seek is completed. If `unregister` is set to
----true, the function `f` will no longer be called when this event occurs, but
----it will error if you never registered the function.
+---Calls the function `f` when seek is completed.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called when the seek is completed.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atseekcompleted(f, unregister) end
 
----If `unregister` is set to true, the function `f` will no longer be called
----when this event occurs, but it will error if you never registered the
----function.
+---Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
+---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(): nil The function to be called.
 ---@param unregister boolean? If true, then unregister the function `f`.
 ---@return nil
 function emu.atwarpmodifystatuschanged(f, unregister) end
 
----Returns the number of VIs since the last movie was played. This should match
----the statusbar. If no movie has been played, it returns the number of VIs
----since the emulator was started, not reset.
+---Returns the number of VIs since the last movie was played.
+---This should match the statusbar.
+---If no movie has been played, it returns the number of VIs since the emulator was started, not reset.
 ---@nodiscard
 ---@return integer framecount The number of VIs since the last movie was played.
 function emu.framecount() end
 
----Returns the number of input frames since the last movie was played. This
----should match the statusbar. If no movie is playing, it will return the last
----value when a movie was playing. If no movie has been played yet, it will
----return `-1`.
+---Returns the number of input frames since the last movie was played.
+---This should match the statusbar.
+---If no movie is playing, it will return the last value when a movie was playing.
+---If no movie has been played yet, it will return `-1`.
 ---@nodiscard
 ---@return integer samplecount The number of input frames since the last movie was played.
 function emu.samplecount() end
@@ -310,9 +288,9 @@ function emu.samplecount() end
 ---@return integer inputcount The number of input frames that have happened since the emulator was started.
 function emu.inputcount() end
 
----Returns the current mupen version. If `type` is 0, it will return the full
----version name (Mupen 64 0.0.0). If `type` is 1, it will return only the
----version number (0.0.0).
+---Returns the current mupen version.
+---If `type` is 0, it will return the full version name (Mupen 64 0.0.0).
+---If `type` is 1, it will return only the version number (0.0.0).
 ---@nodiscard
 ---@param type 0|1 Whether to get the full version (`0`) or the short version (`1`).
 ---@return string version The Mupen version.
@@ -333,11 +311,11 @@ function emu.getpause() end
 ---@return integer speed_limit The current speed limit of the emulator.
 function emu.getspeed() end
 
----Gets whether fast forward is active
+---Gets whether fast forward is active.
 ---@return boolean
 function emu.get_ff() end
 
----Sets whether fast forward is active
+---Sets whether fast forward is active.
 ---@param fast_forward boolean
 function emu.set_ff(fast_forward) end
 
@@ -346,13 +324,14 @@ function emu.set_ff(fast_forward) end
 ---@return nil
 function emu.speed(speed_limit) end
 
----Sets the speed mode of the emulator.
----@deprecated Use [emu.setff](lua://emu.emu.set_ff) instead.
+---Sets the speed mode of the emulator. Use [emu.setff](lua://emu.set_ff) instead.
+---@deprecated Use emu.setff instead.
 ---@param mode "normal"|"maximum"
 ---@return nil
 function emu.speedmode(mode) end
 
----@alias addresses "rdram"
+---@alias addresses
+---|"rdram"
 ---|"rdram_register"
 ---|"MI_register"
 ---|"pi_register"
@@ -367,8 +346,8 @@ function emu.speedmode(mode) end
 ---|"SP_DMEM"
 ---|"PIF_RAM"
 
----Gets the address of an internal mupen variable. For example, "rdram" is the
----same as mupen's ram start
+---Gets the address of an internal mupen variable.
+---For example, "rdram" is the same as mupen's ram start.
 ---@nodiscard
 ---@param address addresses
 ---@return integer
@@ -379,7 +358,7 @@ function emu.getaddress(address) end
 ---@return nil
 function emu.screenshot(dir) end
 
----Played the sound file at `file_path`
+---Played the sound file at `file_path`.
 ---@param file_path string
 ---@return nil
 function emu.play_sound(file_path) end
@@ -395,8 +374,11 @@ function emu.ismainwindowinforeground() end
 -- memory functions
 --#region
 
----Reinterprets the bits of a 4 byte integer `n` as a float and returns it. This
---- does not convert from an int to a float, but reinterprets the memory.
+---A representation of an 8 byte integer (quad word) as two 4 byte integers.
+---@alias qword [integer, integer]
+
+---Reinterprets the bits of a 4 byte integer `n` as a float and returns it.
+---This does not convert from an int to a float, but reinterprets the memory.
 ---@nodiscard
 ---@param n integer
 ---@return number
@@ -409,8 +391,8 @@ function memory.inttofloat(n) end
 ---@return number
 function memory.inttodouble(n) end
 
----Reinterprets the bits of a float `n` as a 4 byte integer and returns it. This
---- does not convert from an int to a float, but reinterprets the memory.
+---Reinterprets the bits of a float `n` as a 4 byte integer and returns it.
+---This does not convert from an int to a float, but reinterprets the memory.
 ---@nodiscard
 ---@param n number
 ---@return integer
@@ -423,8 +405,7 @@ function memory.floattoint(n) end
 ---@return number
 function memory.doubletoint(n) end
 
----Takes in an 8 byte integer and returns it as a lua number. This function
----should only be used when reading a qword from memory.
+---Takes in an 8 byte integer as a table of two 4 bytes integers and returns it as a lua number.
 ---@nodiscard
 ---@param n qword
 ---@return number
@@ -466,15 +447,13 @@ function memory.readdwordsigned(address) end
 ---@return integer
 function memory.readdword(address) end
 
----Reads a signed qword (8 bytes) from memory at `address` and returns it as a
----table of the upper and lower 4 bytes.
+---Reads a signed qword (8 bytes) from memory at `address` and returns it as a table of the upper and lower 4 bytes.
 ---@nodiscard
 ---@param address integer
 ---@return qword
 function memory.readqwordsigned(address) end
 
----Reads an unsigned qword (8 bytes) from memory at `address` and returns it as
----a table of the upper and lower 4 bytes.
+---Reads an unsigned qword (8 bytes) from memory at `address` and returns it as a table of the upper and lower 4 bytes.
 ---@nodiscard
 ---@param address integer
 ---@return integer
@@ -492,8 +471,8 @@ function memory.readfloat(address) end
 ---@return number
 function memory.readdouble(address) end
 
----Reads `size` bytes from memory at `address` and returns them. The memory is
----treated as signed if `size` is is negative.
+---Reads `size` bytes from memory at `address` and returns them.
+---The memory is treated as signed if `size` is is negative.
 ---@nodiscard
 ---@param address integer
 ---@param size 1|2|4|8|-1|-2|-4|-8
@@ -518,8 +497,7 @@ function memory.writeword(address, data) end
 ---@return nil
 function memory.writedword(address, data) end
 
----Writes an unsigned qword consisting of a table with the upper and lower 4
----bytes to memory at `address`.
+---Writes an unsigned qword consisting of a table with the upper and lower 4 bytes to memory at `address`.
 ---@param address integer
 ---@param data qword
 ---@return nil
@@ -537,8 +515,8 @@ function memory.writefloat(address, data) end
 ---@return nil
 function memory.writedouble(address, data) end
 
----Writes `size` bytes to memory at `address`. The memory is treated as signed
----if `size` is is negative.
+---Writes `size` bytes to memory at `address`.
+---The memory is treated as signed if `size` is is negative.
 ---@param address integer
 ---@param size 1|2|4|8|-1|-2|-4|-8
 ---@param data integer|qword
@@ -566,7 +544,7 @@ function memory.recompilenextall() end
 -- wgui functions
 --#region
 
--- colors can be any of these or "#RGB", "#RGBA", "#RRGGBB", or "#RRGGBBA"
+---colors can be any of these or "#RGB", "#RGBA", "#RRGGBB", or "#RRGGBBA"
 ---@alias color
 ---| string
 ---| "white"
@@ -583,32 +561,34 @@ function memory.recompilenextall() end
 ---| "blue"
 ---| "purple"
 
----Sets the current GDI brush color to `color`
+---@alias getrect {l: integer, t: integer, r: integer, b: integer}|{l: integer, t: integer, w: integer, h: integer}
+
+---Sets the current GDI brush color to `color`.
 ---@param color color
 function wgui.setbrush(color) end
 
----GDI: Sets the current GDI pen color to `color`
+---GDI: Sets the current GDI pen color to `color`.
 ---@param color color
 ---@param width number?
 function wgui.setpen(color, width) end
 
----GDI: Sets the current GDI text color to `color`
+---GDI: Sets the current GDI text color to `color`.
 ---@param color color
 function wgui.setcolor(color) end
 
----GDI: Sets the current GDI background color to `color`
+---GDI: Sets the current GDI background color to `color`.
 ---@param color color
 function wgui.setbk(color) end
 
----Sets the font, font size, and font style
+---GDI: Sets the font, font size, and font style.
 ---@param size integer? The size of the font. Defaults to 0 if not given
----@param font string? The name of the font from the operating system. Dafaults to "MS Gothic" if not given
----@param style string? Each character in this string sets one style of the font, applied in chronological order. `b` sets bold, `i` sets italics, `u` sets underline, `s` sets strikethrough, and `a` sets antialiased. Defaults to "" if not given
+---@param font string? The name of the font from the operating system. Dafaults to "MS Gothic" if not given.
+---@param style string? Each character in this string sets one style of the font, applied in chronological order. `b` sets bold, `i` sets italics, `u` sets underline, `s` sets strikethrough, and `a` sets antialiased. Defaults to "" if not given.
 function wgui.setfont(size, font, style) end
 
----GDI: Displays text in one line with the current GDI background color and GDI
----text color
----@deprecated Use `wgui.drawtext` instead
+---GDI: Displays text in one line with the current GDI background color and GDI text color.
+---Use [`wgui.drawtext`](lua://wgui.drawtext) instead.
+---@deprecated Use `wgui.drawtext` instead.
 ---@param x integer
 ---@param y integer
 ---@param text string
@@ -621,6 +601,7 @@ function wgui.text(x, y, text) end
 function wgui.drawtext(text, rect, format) end
 
 ---Uses an alternate function for drawing text.
+---Use [`wgui.drawtext`](lua://wgui.drawtext) instead.
 ---@deprecated Use `wgui.drawtext` unless you have a good reason.
 ---@param text string
 ---@param format integer
@@ -635,9 +616,9 @@ function wgui.drawtextalt(text, format, left, top, right, bottom) end
 ---@return {width: integer, height: integer}
 function wgui.gettextextent(text) end
 
----GDI: Draws a rectangle at the specified coordinates with the current GDI
----background color and a border of the GDI pen color. Only use this function if
----you need rounded corners, otherwise, use `wgui.fillrecta`.
+---GDI: Draws a rectangle at the specified coordinates with the current GDI background color and a border of the GDI pen color.
+---Only use this function if you need rounded corners.
+---Otherwise, use [`wgui.fillrecta`](lua://wgui.fillrecta).
 ---@param left integer
 ---@param top integer
 ---@param right integer
@@ -647,6 +628,7 @@ function wgui.gettextextent(text) end
 function wgui.rect(left, top, right, bottom, rounded_width, rounded_height) end
 
 ---Draws a rectangle at the specified coordinates with the specified color.
+---Use [`wgui.fillrecta`](lua://wgui.fillrecta) instead.
 ---@deprecated Use `wgui.fillrecta`.
 ---@param left integer
 ---@param top integer
@@ -665,7 +647,7 @@ function wgui.fillrect(left, top, right, bottom, red, green, blue) end
 ---@param color color|string Color names are currently broken
 function wgui.fillrecta(x, y, w, h, color) end
 
----GDIPlus: Draws an ellipse at the specified coordinates, size, and color
+---GDIPlus: Draws an ellipse at the specified coordinates, size, and color.
 ---@param x integer
 ---@param y integer
 ---@param w integer
@@ -674,7 +656,7 @@ function wgui.fillrecta(x, y, w, h, color) end
 function wgui.fillellipsea(x, y, w, h, color) end
 
 ---Draws a filled in polygon using the points in `points`
----@param points integer[][] Ex: `\{\{x1, y1\}, \{x2, y2\}, \{x3, y3\}\}`
+---@param points [integer, integer][] Ex: `{{x1, y1}, {x2, y2}, {x3, y3}}`
 ---@param color color|string Color names are currently broken
 function wgui.fillpolygona(points, color) end
 
@@ -683,24 +665,24 @@ function wgui.fillpolygona(points, color) end
 ---@return integer
 function wgui.loadimage(path) end
 
----Clears one of all images
----@param idx integer The identifier of the image to clear. If it is 0, clear all iamges
+---Clears one or all images.
+---@param idx integer The identifier of the image to clear. If it is 0, clear all iamges.
 function wgui.deleteimage(idx) end
 
----Draws the image at index `idx` at the specified coordinates
+---Draws the image at index `idx` at the specified coordinates.
 ---@param idx integer
 ---@param x integer
 ---@param y integer
 function wgui.drawimage(idx, x, y) end
 
----Draws the image at index `idx` at the specified coordinates and scale
+---Draws the image at index `idx` at the specified coordinates and scale.
 ---@param idx integer
 ---@param x integer
 ---@param y integer
 ---@param s number
 function wgui.drawimage(idx, x, y, s) end
 
----Draws the image at index `idx` at the specified coordinates and size
+---Draws the image at index `idx` at the specified coordinates and size.
 ---@param idx integer
 ---@param x integer
 ---@param y integer
@@ -708,7 +690,7 @@ function wgui.drawimage(idx, x, y, s) end
 ---@param h integer
 function wgui.drawimage(idx, x, y, w, h) end
 
----Draws the image at index `idx` at the specified coordinates, size, and rotation, using a part of the source image given by the `src` parameters
+---Draws the image at index `idx` at the specified coordinates, size, and rotation, using a part of the source image given by the `src` parameters.
 ---@param idx integer
 ---@param x integer
 ---@param y integer
@@ -721,39 +703,39 @@ function wgui.drawimage(idx, x, y, w, h) end
 ---@param rotate number
 function wgui.drawimage(idx, x, y, w, h, srcx, srcy, srcw, srch, rotate) end
 
----Captures the current screen and saves it as an image
----@return integer The identifier of the saved image
+---Captures the current screen and saves it as an image.
+---@return integer id The identifier of the saved image.
 function wgui.loadscreen() end
 
----Re-initializes loadscreen
+---Re-initializes loadscreen.
 function wgui.loadscreenreset() end
 
----Returns the width and height of the image at `idx`
+---Returns the width and height of the image at `idx`.
 ---@param idx integer
 ---@return {width: integer, height: integer}
 function wgui.getimageinfo(idx) end
 
----Draws an ellipse at the specified coordinates and size. Uses the GDI brush
----color for the background and a border of the GDI pen color
+---Draws an ellipse at the specified coordinates and size.
+---Uses the GDI brush color for the background and a border of the GDI pen color.
 ---@param left integer
 ---@param top integer
 ---@param right integer
 ---@param bottom integer
 function wgui.ellipse(left, top, right, bottom) end
 
----Draws a polygon with the given points. Uses the GDI brush color for the
----background and a border of the GDI pen color
+---Draws a polygon with the given points.
+---Uses the GDI brush color for the background and a border of the GDI pen color.
 ---@param points integer[][]
 function wgui.polygon(points) end
 
----Draws a line from `(x1, y1)` to `(x2, y2)`
+---Draws a line from `(x1, y1)` to `(x2, y2)`.
 ---@param x1 integer
 ---@param y1 integer
 ---@param x2 integer
 ---@param y2 integer
 function wgui.line(x1, y1, x2, y2) end
 
----Returns the current width and height of the mupen window in a table
+---Returns the current width and height of the mupen window in a table.
 ---@return {width: integer, height: integer}
 function wgui.info() end
 
@@ -780,7 +762,7 @@ function wgui.resetclip() end
 
 ---@alias brush integer
 
----Creates a brush from a color and returns it. D2D colors range from 0 to 1
+---Creates a brush from a color and returns it. D2D colors range from 0 to 1.
 ---@param r number
 ---@param g number
 ---@param b number
@@ -788,13 +770,14 @@ function wgui.resetclip() end
 ---@return brush
 function d2d.create_brush(r, g, b, a) end
 
----Frees a brush. It is a good practice to free all brushes after you are done
----using them
+---Frees a brush.
+---It is a good practice to free all brushes after you are done using them.
 ---@param brush brush
 function d2d.free_brush(brush) end
 
----Sets clear behavior. If this function is never called, the screen will not be
----cleared. If it is called, the screen will be cleared with the specified color
+---Sets clear behavior.
+---If this function is never called, the screen will not be cleared.
+---If it is called, the screen will be cleared with the specified color.
 ---@param r number
 ---@param g number
 ---@param b number
@@ -849,8 +832,7 @@ function d2d.draw_ellipse(x, y, radiusX, radiusY, thickness, brush) end
 ---@return nil
 function d2d.draw_line(x1, y1, x2, y2, thickness, brush) end
 
----Draws the text `text` at the specified coordinates, color, font, and
----alignment.
+---Draws the text `text` at the specified coordinates, color, font, and alignment.
 ---@param x1 integer
 ---@param y1 integer
 ---@param x2 integer
@@ -865,7 +847,9 @@ function d2d.draw_line(x1, y1, x2, y2, thickness, brush) end
 ---@param options integer
 ---@param brush brush pass 0 if you don't know what you're doing
 ---@return nil
-function d2d.draw_text(x1, y1, x2, y2, text, fontname, fontsize, fontweight, fontstyle, horizalign, vertalign, options, brush) end
+function d2d.draw_text(x1, y1, x2, y2, text, fontname, fontsize, fontweight,
+                       fontstyle, horizalign, vertalign, options, brush)
+end
 
 ---Returns the width and height of the specified text.
 ---@param text string
@@ -877,8 +861,8 @@ function d2d.draw_text(x1, y1, x2, y2, text, fontname, fontsize, fontweight, fon
 function d2d.get_text_size(text, fontname, fontsize, max_width, max_height) end
 
 ---Specifies a rectangle to which all subsequent drawing operations are clipped.
----This clip is put onto a stack. It can then be popped off the stack with
----`wgui.d2d_pop_clip`.
+---This clip is put onto a stack.
+---It can then be popped off the stack with `wgui.d2d_pop_clip`.
 ---@param x1 integer
 ---@param y1 integer
 ---@param x2 integer
@@ -890,8 +874,7 @@ function d2d.push_clip(x1, y1, x2, y2) end
 ---@return nil
 function d2d.pop_clip() end
 
----Draws a filled in rounded rectangle at the specified coordinates, color and
----radius.
+---Draws a filled in rounded rectangle at the specified coordinates, color and radius.
 ---@param x1 integer
 ---@param y1 integer
 ---@param x2 integer
@@ -902,8 +885,7 @@ function d2d.pop_clip() end
 ---@return nil
 function d2d.fill_rounded_rectangle(x1, y1, x2, y2, radiusX, radiusY, brush) end
 
----Draws the border of a rounded rectangle at the specified coordinates, color
----and radius.
+---Draws the border of a rounded rectangle at the specified coordinates, color and radius.
 ---@param x1 integer
 ---@param y1 integer
 ---@param x2 integer
@@ -913,10 +895,10 @@ function d2d.fill_rounded_rectangle(x1, y1, x2, y2, radiusX, radiusY, brush) end
 ---@param thickness number
 ---@param brush brush
 ---@return nil
-function d2d.draw_rounded_rectangle(x1, y1, x2, y2, radiusX, radiusY, thickness, brush) end
+function d2d.draw_rounded_rectangle(x1, y1, x2, y2, radiusX, radiusY, thickness,
+                                    brush) end
 
----Loads an image file from `path` which you can then access through
----`identifier`.
+---Loads an image file from `path` which you can then access through `identifier`.
 ---@param path string
 ---@return integer
 function d2d.load_image(path) end
@@ -926,8 +908,7 @@ function d2d.load_image(path) end
 ---@return nil
 function d2d.free_image(identifier) end
 
----Draws an image by taking the pixels in the source rectangle of the image, and
----drawing them to the destination rectangle on the screen.
+---Draws an image by taking the pixels in the source rectangle of the image, and drawing them to the destination rectangle on the screen.
 ---@param destx1 integer
 ---@param desty1 integer
 ---@param destx2 integer
@@ -940,7 +921,8 @@ function d2d.free_image(identifier) end
 ---@param interpolation integer 0: nearest neighbor, 1: linear, -1: don't use.
 ---@param identifier number
 ---@return nil
-function d2d.draw_image(destx1, desty1, destx2, desty2, srcx1, srcy1, srcx2, srcy2, opacity, interpolation, identifier) end
+function d2d.draw_image(destx1, desty1, destx2, desty2, srcx1, srcy1, srcx2,
+                        srcy2, opacity, interpolation, identifier) end
 
 ---Returns the width and height of the image at `identifier`.
 ---@nodiscard
@@ -948,17 +930,17 @@ function d2d.draw_image(destx1, desty1, destx2, desty2, srcx1, srcy1, srcx2, src
 ---@return {width: integer, height: integer}
 function d2d.get_image_info(identifier) end
 
----Sets the text antialiasing mode. More info
----[here](https://learn.microsoft.com/en-us/windows/win32/api/d2d1/ne-d2d1-d2d1_text_antialias_mode).
+---Sets the text antialiasing mode.
+---More info [here](https://learn.microsoft.com/en-us/windows/win32/api/d2d1/ne-d2d1-d2d1_text_antialias_mode).
 ---@param mode 0|1|2|3|4294967295
 function d2d.set_text_antialias_mode(mode) end
 
----Sets the antialiasing mode. More info
----[here](https://learn.microsoft.com/en-us/windows/win32/api/d2d1/ne-d2d1-d2d1_antialias_mode).
+---Sets the antialiasing mode.
+---More info [here](https://learn.microsoft.com/en-us/windows/win32/api/d2d1/ne-d2d1-d2d1_antialias_mode).
 ---@param mode 0|1|4294967295
 function d2d.set_antialias_mode(mode) end
 
----Draws to an image and returns its identifier
+---Draws to an image and returns its identifier.
 ---@param width integer
 ---@param height integer
 ---@param callback fun()
@@ -971,31 +953,148 @@ function d2d.draw_to_image(width, height, callback) end
 -- input functions
 --#region
 
----Returns the state of all keyboard keys and the mouse position in a table. Ex:
----`input.get() -> {xmouse=297, ymouse=120, A=true, B=true}`.
+
+---@alias Keys {
+---leftclick: boolean?,
+---rightclick: boolean?,
+---middleclick: boolean?,
+---backspace: boolean?,
+---tab: boolean?,
+---enter: boolean?,
+---shift: boolean?,
+---control: boolean?,
+---alt: boolean?,
+---pause: boolean?,
+---capslock: boolean?,
+---escape: boolean?,
+---space: boolean?,
+---pageup: boolean?,
+---pagedown: boolean?,
+---end: boolean?,
+---home: boolean?,
+---left: boolean?,
+---up: boolean?,
+---right: boolean?,
+---down: boolean?,
+---insert: boolean?,
+---delete: boolean?,
+---["0"]: boolean?,
+---["1"]: boolean?,
+---["2"]: boolean?,
+---["3"]: boolean?,
+---["4"]: boolean?,
+---["5"]: boolean?,
+---["6"]: boolean?,
+---["7"]: boolean?,
+---["8"]: boolean?,
+---["9"]: boolean?,
+---A: boolean?,
+---B: boolean?,
+---C: boolean?,
+---D: boolean?,
+---E: boolean?,
+---F: boolean?,
+---G: boolean?,
+---H: boolean?,
+---I: boolean?,
+---J: boolean?,
+---K: boolean?,
+---L: boolean?,
+---M: boolean?,
+---N: boolean?,
+---O: boolean?,
+---P: boolean?,
+---Q: boolean?,
+---R: boolean?,
+---S: boolean?,
+---T: boolean?,
+---U: boolean?,
+---V: boolean?,
+---W: boolean?,
+---X: boolean?,
+---Y: boolean?,
+---Z: boolean?,
+---numpad0: boolean?,
+---numpad1: boolean?,
+---numpad2: boolean?,
+---numpad3: boolean?,
+---numpad4: boolean?,
+---numpad5: boolean?,
+---numpad6: boolean?,
+---numpad7: boolean?,
+---numpad8: boolean?,
+---numpad9: boolean?,
+---numpad*: boolean?,
+---["numpad+"]: boolean?,
+---numpad-: boolean?,
+---numpad.: boolean?,
+---["numpad/"]: boolean?,
+---F1: boolean?,
+---F2: boolean?,
+---F3: boolean?,
+---F4: boolean?,
+---F5: boolean?,
+---F6: boolean?,
+---F7: boolean?,
+---F8: boolean?,
+---F9: boolean?,
+---F10: boolean?,
+---F11: boolean?,
+---F12: boolean?,
+---F13: boolean?,
+---F14: boolean?,
+---F15: boolean?,
+---F16: boolean?,
+---F17: boolean?,
+---F18: boolean?,
+---F19: boolean?,
+---F20: boolean?,
+---F21: boolean?,
+---F22: boolean?,
+---F23: boolean?,
+---F24: boolean?,
+---numlock: boolean?,
+---scrolllock: boolean?,
+---semicolon: boolean?,
+---plus: boolean?,
+---comma: boolean?,
+---minus: boolean?,
+---period: boolean?,
+---slash: boolean?,
+---tilde: boolean?,
+---leftbracket: boolean?,
+---backslash: boolean?,
+---rightbracket: boolean?,
+---quote: boolean?,
+---xmouse: integer,
+---ymouse: integer,
+---ywmouse: integer,
+---}
+
+---Returns the state of all keyboard keys and the mouse position in a table.
+---Ex: `input.get() -> {xmouse=297, ymouse=120, A=true, B=true}`.
 ---@nodiscard
----@return table
+---@return Keys
 function input.get() end
 
----Returns the differences between `t1` and `t2`. For example, if `t1` is the
----inputs for this frame, and `t2` is the inputs for last frame, it would return
----which buttons were pressed this frame, not which buttons are active.
+---Returns the differences between `t1` and `t2`.
+---For example, if `t1` is the inputs for this frame, and `t2` is the inputs for last frame, it would return which buttons were pressed this frame, not which buttons are active.
 ---@nodiscard
 ---@param t1 table
 ---@param t2 table
 ---@return table
 function input.diff(t1, t2) end
 
----Opens a window where the user can input text. If `OK` is clicked, that text
----is returned. If `Cancel` is clicked or the window is closed, `nil` is
----returned.
+---Opens a window where the user can input text.
+---If `OK` is clicked, that text is returned.
+---If `Cancel` is clicked or the window is closed, `nil` is returned.
 ---@nodiscard
 ---@param title string? The title of the text box. Defaults to "input:".
 ---@param placeholder string? The text box is filled with this string when it opens. Defaults to "".
 ---@return string|nil
 function input.prompt(title, placeholder) end
 
----Gets the name of a key
+---Gets the name of a key.
 ---@nodiscard
 ---@param key integer
 ---@return string
@@ -1007,18 +1106,43 @@ function input.get_key_name_text(key) end
 -- joypad functions
 --#region
 
+---@alias JoypadInputs {
+---right: boolean,
+---left: boolean,
+---down: boolean,
+---up: boolean,
+---start: boolean,
+---Z: boolean,
+---B: boolean,
+---A: boolean,
+---Cright: boolean,
+---Cleft: boolean,
+---Cdown: boolean,
+---Cup: boolean,
+---R: boolean,
+---L: boolean,
+---Y: integer,
+---X: integer,
+---}
+
+
 ---Gets the currently pressed game buttons and stick direction for a given port.
----Note that the `y` coordinate of the stick is the opposite of what is shown on
----TAS Input.
+---If `port` is nil, the data for port 1 will be returned.
+---Note that the `y` coordinate of the stick is the opposite of what is shown on TAS Input.
 ---@nodiscard
----@param port 1|2|3|4
----@return table
+---@param port? 1|2|3|4
+---@return JoypadInputs
 function joypad.get(port) end
 
----Sets the current joypad to `inputs`. If you do not specify one or more
----inputs, they will be set to `false` for buttons or `0` for stick coordinates.
+---Sets the input state for port 0 to `inputs`.
+---If you do not specify one or more inputs, they will be set to `false` for buttons or `0` for stick coordinates.
+---@param inputs JoypadInputs
+function joypad.set(inputs) end
+
+---Sets the input state for a given port to `inputs`.
+---If you do not specify one or more inputs, they will be set to `false` for buttons or `0` for stick coordinates.
 ---@param port 1|2|3|4
----@param inputs table
+---@param inputs JoypadInputs
 ---@return nil
 function joypad.set(port, inputs) end
 
@@ -1035,8 +1159,8 @@ function joypad.count() end
 -- movie functions
 --#region
 
----Plays a movie file located at `filename`. This function sets `Read Only` to
----true.
+---Plays a movie file located at `filename`.
+---This function sets `Read Only` to true.
 ---@param filename string
 ---@return nil
 function movie.play(filename) end
@@ -1045,38 +1169,39 @@ function movie.play(filename) end
 ---@return nil
 function movie.stop() end
 
----Returns the filename of the currently playing movie. It will error if no
----movie is playing.
+---Returns the filename of the currently playing movie.
+---It will error if no movie is playing.
 ---@nodiscard
 ---@return string
 function movie.get_filename() end
 
----Returns true if the currently playing movie is read only
+---Returns true if the currently playing movie is read only.
+---@nodiscard
 ---@return boolean
 function movie.get_readonly() end
 
----Set's the currently movie's readonly state to `readonly`
+---Set's the currently movie's readonly state to `readonly`.
 ---@param readonly boolean
 function movie.set_readonly(readonly) end
 
----Begins seeking
+---Begins seeking.
 ---@param str string
 ---@param pause_at_end boolean
 ---@return integer
 function movie.begin_seek(str, pause_at_end) end
 
----Stops seeking
+---Stops seeking.
 function movie.stop_seek() end
 
----Returns whether the emulator is currently seeking
+---Returns whether the emulator is currently seeking.
 ---@return boolean
 function movie.is_seeking() end
 
----Gets info about the current seek
+---Gets info about the current seek.
 ---@return [integer, integer]
 function movie.get_seek_completion() end
 
----Begins a warp modify
+---Begins a warp modify.
 ---@param inputs {[string]: boolean}[]
 function movie.begin_warp_modify(inputs) end
 
@@ -1091,16 +1216,19 @@ function movie.begin_warp_modify(inputs) end
 ---@return nil
 function savestate.savefile(filename) end
 
----Loads a savestate from `filename`
+---Loads a savestate from `filename`.
 ---@param filename string
 ---@return nil
 function savestate.loadfile(filename) end
 
----@alias SavestateCallback fun(result: Result, data: ByteBuffer): nil
----Represents a callback function for a savestate operation.
+---A byte buffer encoded as a string.
+---@alias ByteBuffer string
 
----@alias SavestateJob "save" | "load"
+---Represents a callback function for a savestate operation.
+---@alias SavestateCallback fun(result: Result, data: ByteBuffer): nil
+
 ---Represents a savestate job.
+---@alias SavestateJob "save" | "load"
 
 ---Executes a savestate operation to a path.
 ---@param path string The savestate's path.
@@ -1142,8 +1270,8 @@ function iohelper.filediag(filter, type) end
 -- avi functions
 --#region
 
----Begins an avi recording using the previously saved encoding settings. It is
----saved to `filename`.
+---Begins an avi recording using the previously saved encoding settings.
+---It is saved to `filename`.
 ---@param filename string
 ---@return nil
 function avi.startcapture(filename) end

--- a/tools/mupenapi.lua
+++ b/tools/mupenapi.lua
@@ -101,7 +101,7 @@ Mupen = {
 
 ---The `lua_tostring` c function converts numbers to strings, so numbers are
 ---acceptable to pass into some functions that use that function.
----@alias tostringusable string|number
+---@alias tostringusable string|number 
 
 
 -- Global Functions
@@ -178,7 +178,6 @@ function emu.atdrawd2d(f, unregister) end
 
 ---Calls the function `f` every input frame.
 ---The function `f` receives an argument that seems to always be `0`.
----Emulator execution may be running in parallel with this callback and it's therefore disallowed to call any functions that perform unsynchronized reads or writes from and to the emulator state, such as those from the memory namespace.
 ---If `unregister` is set to true, the function `f` will no longer be called when this event occurs, but it will error if you never registered the function.
 ---@param f fun(a: integer?): nil The function to be called every input frame. It receives an argument that seems to always be `0`.
 ---@param unregister boolean? If true, then unregister the function `f`.
@@ -375,7 +374,7 @@ function emu.ismainwindowinforeground() end
 --#region
 
 ---A representation of an 8 byte integer (quad word) as two 4 byte integers.
----@alias qword [integer, integer]
+---@alias qword [integer, integer] 
 
 ---Reinterprets the bits of a 4 byte integer `n` as a float and returns it.
 ---This does not convert from an int to a float, but reinterprets the memory.
@@ -848,8 +847,7 @@ function d2d.draw_line(x1, y1, x2, y2, thickness, brush) end
 ---@param brush brush pass 0 if you don't know what you're doing
 ---@return nil
 function d2d.draw_text(x1, y1, x2, y2, text, fontname, fontsize, fontweight,
-                       fontstyle, horizalign, vertalign, options, brush)
-end
+                       fontstyle, horizalign, vertalign, options, brush) end
 
 ---Returns the width and height of the specified text.
 ---@param text string


### PR DESCRIPTION
Removed `emu.setgfx` as it previously did nothing
Restructured and reformatted mupenapi.lua
- removed `printx` as it has been deprecated
- added emulator state warning to all `emu.atxyz` function except `emu.atvi` and `emu.atinput`
- added strong typing for `input.get` and `joypad.get`