### PR TITLE
refactor: remove `plugin_version` field from M64RR plugin spec

### DIFF
--- a/src/Common/include/Common/DummyPluginStub.hpp
+++ b/src/Common/include/Common/DummyPluginStub.hpp
@@ -18,15 +18,10 @@
         const char *description = "Built-in plugin for Mupen64."                                                       \
                                   "\n\n"                                                                               \
                                   "https://mupen64.com";                                                               \
-        const char *target_version = CURRENT_VERSION;                                                                  \
                                                                                                                        \
         auto result = std::format_to_n(metadata->name, sizeof(metadata->name) - 1, "{}", name);                        \
         metadata->name[result.size] = '\0';                                                                            \
                                                                                                                        \
         result = std::format_to_n(metadata->description, sizeof(metadata->description) - 1, "{}", description);        \
         metadata->description[result.size] = '\0';                                                                     \
-                                                                                                                       \
-        result =                                                                                                       \
-            std::format_to_n(metadata->target_version, sizeof(metadata->target_version) - 1, "{}", target_version);    \
-        metadata->target_version[result.size] = '\0';                                                                  \
     }

--- a/src/Core/include/m64rr/Plugin.hpp
+++ b/src/Core/include/m64rr/Plugin.hpp
@@ -81,7 +81,6 @@ extern "C"
         PluginType type;
         char name[128];
         char description[1024];
-        char target_version[32];
     };
 
     /**

--- a/src/Plugins.TASAudio/Main.cpp
+++ b/src/Plugins.TASAudio/Main.cpp
@@ -87,16 +87,12 @@ EXPORT void CALL M64RRGetMetadata(M64RRSpec::PluginMetadata *metadata)
     const auto description = "Built-in plugin for Mupen64."
                              "\n\n"
                              "https://mupen64.com";
-    const auto target_version = CURRENT_VERSION;
 
     auto result = std::format_to_n(metadata->name, sizeof(metadata->name) - 1, "{}", name);
     metadata->name[result.size] = '\0';
 
     result = std::format_to_n(metadata->description, sizeof(metadata->description) - 1, "{}", description);
     metadata->description[result.size] = '\0';
-
-    result = std::format_to_n(metadata->target_version, sizeof(metadata->target_version) - 1, "{}", target_version);
-    metadata->target_version[result.size] = '\0';
 }
 
 EXPORT void CALL M64RRProcessEvent(Event event)

--- a/src/Plugins.TASRSP/Main.cpp
+++ b/src/Plugins.TASRSP/Main.cpp
@@ -173,16 +173,12 @@ EXPORT void CALL M64RRGetMetadata(M64RRSpec::PluginMetadata *metadata)
     const auto description = "Built-in plugin for Mupen64."
                              "\n\n"
                              "https://mupen64.com";
-    const auto target_version = CURRENT_VERSION;
 
     auto result = std::format_to_n(metadata->name, sizeof(metadata->name) - 1, "{}", name);
     metadata->name[result.size] = '\0';
 
     result = std::format_to_n(metadata->description, sizeof(metadata->description) - 1, "{}", description);
     metadata->description[result.size] = '\0';
-
-    result = std::format_to_n(metadata->target_version, sizeof(metadata->target_version) - 1, "{}", target_version);
-    metadata->target_version[result.size] = '\0';
 }
 
 EXPORT void CALL M64RRProcessEvent(Event event)

--- a/src/Plugins.TASVideo/TASVideo.cpp
+++ b/src/Plugins.TASVideo/TASVideo.cpp
@@ -41,16 +41,12 @@ EXPORT void CALL M64RRGetMetadata(M64RRSpec::PluginMetadata *metadata)
     const auto description = "Built-in plugin for Mupen64."
                              "\n\n"
                              "https://mupen64.com";
-    const auto target_version = CURRENT_VERSION;
 
     auto result = std::format_to_n(metadata->name, sizeof(metadata->name) - 1, "{}", name);
     metadata->name[result.size] = '\0';
 
     result = std::format_to_n(metadata->description, sizeof(metadata->description) - 1, "{}", description);
     metadata->description[result.size] = '\0';
-
-    result = std::format_to_n(metadata->target_version, sizeof(metadata->target_version) - 1, "{}", target_version);
-    metadata->target_version[result.size] = '\0';
 }
 
 EXPORT void CALL M64RRProcessEvent(Event event)

--- a/src/Plugins.Win32.TASInput/TASInput.cpp
+++ b/src/Plugins.Win32.TASInput/TASInput.cpp
@@ -1190,16 +1190,12 @@ EXPORT void CALL M64RRGetMetadata(M64RRSpec::PluginMetadata *metadata)
     const auto description = "Built-in plugin for Mupen64."
                              "\n\n"
                              "https://mupen64.com";
-    const auto target_version = CURRENT_VERSION;
 
     auto result = std::format_to_n(metadata->name, sizeof(metadata->name) - 1, "{}", name);
     metadata->name[result.size] = '\0';
 
     result = std::format_to_n(metadata->description, sizeof(metadata->description) - 1, "{}", description);
     metadata->description[result.size] = '\0';
-
-    result = std::format_to_n(metadata->target_version, sizeof(metadata->target_version) - 1, "{}", target_version);
-    metadata->target_version[result.size] = '\0';
 }
 
 EXPORT void CALL M64RRProcessEvent(Event event)

--- a/src/Views.Qt6/Core/plugin/Plugin.cpp
+++ b/src/Views.Qt6/Core/plugin/Plugin.cpp
@@ -60,12 +60,6 @@ void Plugin::init_common()
     M64RRSpec::PluginMetadata metadata;
     get_metadata(&metadata);
 
-    // Plugins are tied to one version of Mupen
-    std::string_view target_version{
-        metadata.target_version, strnlen(metadata.target_version, sizeof(metadata.target_version))};
-    if (!target_version.empty() && target_version != CURRENT_VERSION)
-        throw PluginLoadFailed("Expected target version " CURRENT_VERSION);
-
     std::string_view name = {metadata.name, strnlen(metadata.name, sizeof(metadata.name))};
     m_name = name;
 

--- a/src/Views.Win32/plugin/M64RRPlugin.cpp
+++ b/src/Views.Win32/plugin/M64RRPlugin.cpp
@@ -65,18 +65,6 @@ std::pair<std::string, std::unique_ptr<Plugin>> M64RRPlugin::create(HMODULE modu
     M64RRSpec::PluginMetadata metadata{};
     get_metadata(&metadata);
 
-    const size_t target_version_len = strnlen(metadata.target_version, std::size(metadata.target_version));
-    if (target_version_len > 0)
-    {
-        // Plugin is tied to one version of mupen
-        const auto current_version = CURRENT_VERSION;
-        const std::string target_version(metadata.target_version, target_version_len);
-        if (current_version != target_version)
-        {
-            return std::make_pair("Incompatible with this version of Mupen64", nullptr);
-        }
-    }
-
     const size_t plugin_name_len = strlen(metadata.name);
     while (plugin_name_len > 0 && metadata.name[plugin_name_len - 1] == ' ')
     {


### PR DESCRIPTION
built-in plugins are statically linked; this is not necessary anymore