### PR TITLE
feat(Lua)!: modernize `Hotkey`

### DIFF
--- a/docs/win/9._Lua-Scripting.md
+++ b/docs/win/9._Lua-Scripting.md
@@ -16,11 +16,11 @@ Most IDEs should now automatically recognize the API definitions and provide cod
 
 # Migration Guides
 
-## SDL keycodes (from 1.5.0-2)
+## Keycodes and hotkey triggers (from 1.5.0-2)
 
-Lua APIs now use SDL 3 keycodes instead of Windows virtual keycodes.
+The Lua API now uses SDL keycodes and mousebutton flags instead of Windows virtual keycodes.
 
-This change was necessary to decouple Lua scripts from Windows, but it requires changes to scripts which use affected APIs.
+Hotkeys now also use a `trigger` table (that provides additional functionality) instead of the `key` and `assigned` fields.
 
 ### Enum names
 
@@ -30,8 +30,6 @@ Replace `Mupen.VKeycodes.VK_*` with the corresponding `Mupen.keycode.SDLK_*` val
 - local key = Mupen.VKeycodes.VK_RETURN
 + local key = Mupen.keycode.SDLK_RETURN
 ```
-
-The `Mupen.keycode` enum follows SDL's naming and values, including names such as `SDLK_A`, `SDLK_F1`, `SDLK_LEFT`, `SDLK_KP_0`, and `SDLK_LCTRL`.
 
 ### Key event callbacks
 
@@ -57,17 +55,25 @@ The `Mupen.keycode` enum follows SDL's naming and values, including names such a
 +input.get_key_name_text(Mupen.keycode.SDLK_DOWN)
 ```
 
-### Hotkeys and actions
+### Hotkeys
 
-Hotkey table fields use SDL keycodes as well:
+Move the SDL keycode into a `keycode` trigger:
 
 ```diff
  action.associate_hotkey("Movie > Pause", {
 -    key = Mupen.VKeycodes.VK_P,
-+    key = Mupen.keycode.SDLK_P,
++    trigger = { type = "keycode", value = Mupen.keycode.SDLK_P },
      ctrl = true,
  }, true)
 ```
+
+The supported triggers are:
+
+- Keyboard: `{ type = "keycode", value = Mupen.keycode.SDLK_* }`
+- Mouse: `{ type = "mousebutton", value = Mupen.mousebutton.SDL_BUTTON_*MASK }`
+- Unassigned: `{ type = "none" }`
+
+Use `Mupen.keycode.SDLK_UNKNOWN` for an assigned but empty hotkey. `hotkey.prompt` returns this same structure.
 
 ### Mouse-button flags
 

--- a/src/Lua/api.lua
+++ b/src/Lua/api.lua
@@ -1742,12 +1742,28 @@ function avi.stopcapture() end
 -- hotkey functions
 --#region
 
----@class Hotkey Represents a combination of keys.
----@field key Keycode? The SDL keycode that is pressed to trigger the hotkey.
----@field ctrl boolean? Whether the control modifier is pressed.
----@field shift boolean? Whether the shift modifier is pressed.
----@field alt boolean? Whether the alt modifier is pressed.
----@field assigned boolean? Whether the hotkey is assigned. Defaults to `true`.
+---@class HotkeyNoTrigger
+---@field type "none"
+---Represents an unassigned hotkey trigger.
+
+---@class HotkeyKeyCodeTrigger
+---@field type "keycode"
+---@field value Keycode The SDL keycode that triggers the hotkey.
+---Represents a keyboard hotkey trigger.
+
+---@class HotkeyMouseButtonTrigger
+---@field type "mousebutton"
+---@field value MouseButtonFlags The SDL mouse-button flag that triggers the hotkey.
+---Represents a mouse hotkey trigger.
+
+---@alias HotkeyTrigger HotkeyNoTrigger|HotkeyKeyCodeTrigger|HotkeyMouseButtonTrigger
+
+---@class Hotkey
+---@field trigger HotkeyTrigger The event that triggers the hotkey.
+---@field ctrl boolean? Whether the control modifier is pressed. Defaults to `false`.
+---@field shift boolean? Whether the shift modifier is pressed. Defaults to `false`.
+---@field alt boolean? Whether the alt modifier is pressed. Defaults to `false`.
+---Represents a trigger and its keyboard modifiers. Can invoke an action.
 
 ---Shows a dialog prompting the user to enter a hotkey.
 ---@param caption string The headline to display in the dialog.

--- a/src/Lua/manual/action_system.lua
+++ b/src/Lua/manual/action_system.lua
@@ -14,7 +14,7 @@
 -- 5. The hotkey for "Change Name of This Action..." works (default Ctrl+U)
 -- 6. Pressing "Change Hotkey..." prompts for a new hotkey and changes the hotkey of "Change Name of This Action..."
 -- 7. Pressing "Click Child to Remove It > Item X" removes that action
--- 8. Pressing "Parameterized Action..." prompts for a parameter with a prefilled value and a few hints, and prints it to the console. 
+-- 8. Pressing "Parameterized Action..." prompts for a parameter with a prefilled value and a few hints, and prints it to the console.
 -- 9. Stopping the script removes the "Action API Demo" menu.
 
 dofile(debug.getinfo(1).source:sub(2):gsub("\\[^\\]+\\[^\\]+$", "") .. '\\test_prelude.lua')
@@ -80,7 +80,7 @@ assert(action.add({
             get_initial_value = function()
                 return tostring(os.clock())
             end,
-            get_hints = function (value)
+            get_hints = function(value)
                 return {
                     "Current time is " .. tostring(os.clock()),
                     "You entered: " .. tostring(value)
@@ -110,6 +110,9 @@ for i = 1, 10, 1 do
 end
 
 assert(action.associate_hotkey(CHANGE_NAME_ACTION, {
-    key = string.byte("U"),
+    trigger = {
+        type = "keycode",
+        value = Mupen.keycode.SDLK_U,
+    },
     ctrl = true,
 }, false))

--- a/src/Lua/tests.lua
+++ b/src/Lua/tests.lua
@@ -1003,23 +1003,60 @@ retest.describe('mupen64', function()
                 retest.expect(func).to.fail()
             end)
             retest.it('returns_false_when_action_doesnt_exist', function()
-                local result = action.associate_hotkey("Test > Something", {})
+                local result = action.associate_hotkey("Test > Something", {
+                    trigger = { type = "none" },
+                })
                 retest.expect(result).to.equal(false)
             end)
             retest.it('returns_false_when_path_isnt_fully_qualified', function()
                 action.add({
                     path = "Test > Something",
                 })
-                local result = action.associate_hotkey("Test > *", {})
+                local result = action.associate_hotkey("Test > *", {
+                    trigger = { type = "none" },
+                })
                 retest.expect(result).to.equal(false)
             end)
-            retest.it('works_when_parameters_valid', function()
+            retest.it('errors_when_trigger_is_missing', function()
+                action.add({
+                    path = "Test > Something",
+                })
+                local func = function()
+                    action.associate_hotkey("Test > Something", {})
+                end
+                retest.expect(func).to.fail()
+            end)
+            retest.it('works_with_keycode_trigger', function()
                 action.add({
                     path = "Test > Something",
                 })
                 local result = action.associate_hotkey("Test > Something", {
-                    key = Mupen.keycode.SDLK_F1,
+                    trigger = {
+                        type = "keycode",
+                        value = Mupen.keycode.SDLK_F1,
+                    },
                     alt = true,
+                }, true)
+                retest.expect(result).to.be.truthy()
+            end)
+            retest.it('works_with_mousebutton_trigger', function()
+                action.add({
+                    path = "Test > Something",
+                })
+                local result = action.associate_hotkey("Test > Something", {
+                    trigger = {
+                        type = "mousebutton",
+                        value = Mupen.mousebutton.SDL_BUTTON_X1MASK,
+                    },
+                }, true)
+                retest.expect(result).to.be.truthy()
+            end)
+            retest.it('works_with_no_trigger', function()
+                action.add({
+                    path = "Test > Something",
+                })
+                local result = action.associate_hotkey("Test > Something", {
+                    trigger = { type = "none" },
                 }, true)
                 retest.expect(result).to.be.truthy()
             end)

--- a/src/Views.Win32/lua/modules/Hotkey.hpp
+++ b/src/Views.Win32/lua/modules/Hotkey.hpp
@@ -13,56 +13,76 @@
 
 namespace LuaCore::Hotkey
 {
+static void push_trigger(lua_State *L, const ::Hotkey::Trigger &trigger)
+{
+    lua_newtable(L);
+
+    if (std::holds_alternative<std::monostate>(trigger))
+    {
+        lua_pushstring(L, "none");
+    }
+    else if (std::holds_alternative<::Hotkey::KeyCode>(trigger))
+    {
+        lua_pushstring(L, "keycode");
+        lua_pushinteger(L, std::get<::Hotkey::KeyCode>(trigger).get());
+        lua_setfield(L, -2, "value");
+    }
+    else
+    {
+        lua_pushstring(L, "mousebutton");
+        lua_pushinteger(L, std::get<::Hotkey::MouseButton>(trigger).get());
+        lua_setfield(L, -2, "value");
+    }
+
+    lua_setfield(L, -2, "type");
+}
+
 static void push_hotkey(lua_State *L, const ::Hotkey &hotkey)
 {
     lua_newtable(L);
 
-    lua_pushstring(L, "key");
-    if (std::holds_alternative<::Hotkey::KeyCode>(hotkey.trigger))
-        lua_pushinteger(L, std::get<::Hotkey::KeyCode>(hotkey.trigger).get());
-    else if (const auto vk = HotkeyUtils::trigger_to_vk(hotkey.trigger); vk.has_value())
-        lua_pushinteger(L, *vk);
-    else
-        lua_pushnil(L);
-    lua_settable(L, -3);
+    push_trigger(L, hotkey.trigger);
+    lua_setfield(L, -2, "trigger");
 
-    lua_pushstring(L, "ctrl");
     lua_pushboolean(L, hotkey.ctrl);
-    lua_settable(L, -3);
+    lua_setfield(L, -2, "ctrl");
 
-    lua_pushstring(L, "shift");
     lua_pushboolean(L, hotkey.shift);
-    lua_settable(L, -3);
+    lua_setfield(L, -2, "shift");
 
-    lua_pushstring(L, "alt");
     lua_pushboolean(L, hotkey.alt);
-    lua_settable(L, -3);
+    lua_setfield(L, -2, "alt");
+}
 
-    // COMPAT
-    lua_pushstring(L, "assigned");
-    lua_pushboolean(L, hotkey.is_assigned());
-    lua_settable(L, -3);
+static ::Hotkey::Trigger check_trigger(lua_State *L, int i)
+{
+    luaL_checktype(L, i, LUA_TTABLE);
+
+    lua_getfield(L, i, "type");
+    const std::string type = luaL_checkstring(L, -1);
+    lua_pop(L, 1);
+
+    if (type == "none") return std::monostate{};
+    if (type != "keycode" && type != "mousebutton")
+    {
+        luaL_error(L, "Unknown hotkey trigger type: %s", type.c_str());
+        std::unreachable();
+    }
+
+    lua_getfield(L, i, "value");
+    const auto value = luaL_checkinteger(L, -1);
+    lua_pop(L, 1);
+
+    if (type == "keycode") return ::Hotkey::KeyCode(static_cast<SDL_Keycode>(value));
+    return ::Hotkey::MouseButton(static_cast<SDL_MouseButtonFlags>(value));
 }
 
 static ::Hotkey check_hotkey(lua_State *L, int i)
 {
-    auto hotkey = ::Hotkey::make_empty();
+    luaL_checktype(L, i, LUA_TTABLE);
 
-    if (!lua_istable(L, i))
-    {
-        luaL_error(L, "Expected a table at argument %d", i);
-        return hotkey;
-    }
-
-    lua_getfield(L, i, "key");
-    const auto keycode = static_cast<SDL_Keycode>(luaL_opt(L, lua_tointeger, -1, SDLK_UNKNOWN));
-    // Prior to 1.5.0-3, these were Windows virtual keycodes.
-    // These values don't overlap valid SDL keycodes, so we can just check for them.
-    if (keycode == VK_LBUTTON || keycode == VK_MBUTTON || keycode == VK_RBUTTON || keycode == VK_XBUTTON1 ||
-        keycode == VK_XBUTTON2)
-        hotkey.trigger = *HotkeyUtils::vk_to_trigger(keycode);
-    else
-        hotkey.trigger = ::Hotkey::KeyCode(keycode);
+    lua_getfield(L, i, "trigger");
+    ::Hotkey hotkey(check_trigger(L, -1));
     lua_pop(L, 1);
 
     lua_getfield(L, i, "ctrl");
@@ -75,12 +95,6 @@ static ::Hotkey check_hotkey(lua_State *L, int i)
 
     lua_getfield(L, i, "alt");
     hotkey.alt = luaL_opt(L, lua_toboolean, -1, false);
-    lua_pop(L, 1);
-
-    // COMPAT
-    lua_getfield(L, i, "assigned");
-    const auto assigned = luaL_opt(L, lua_toboolean, -1, true);
-    if (!assigned) hotkey = ::Hotkey::make_unassigned();
     lua_pop(L, 1);
 
     return hotkey;


### PR DESCRIPTION
Replaced `Hotkey.key` with `trigger` and removed `assigned` (which is now part of `trigger`)

Breaking, see migration guide.